### PR TITLE
Add advertiser statistics by campaign method. Fixed unit tests.

### DIFF
--- a/lib/Exads/Api/Campaign.php
+++ b/lib/Exads/Api/Campaign.php
@@ -147,8 +147,9 @@ class Campaign extends AbstractApi
         return $this->put($path, $data);
     }
 
-    /*
-     * Add new targeted/blocked element to a campaign
+    /**
+     * Add new targeted/blocked element to a campaign.
+     *
      * @param string $elementType [browsers|carriers|categories|countries|devices|languages|operating_systems|sites|keywords|ip_ranges]
      * @param string $id
      * @param string $type [targeted|blocked]
@@ -163,14 +164,15 @@ class Campaign extends AbstractApi
         return $this->post($path, $data);
     }
 
-    /*
-     * Replace targeted/blocked element from a campaign
+    /**
+     * Replace targeted/blocked element from a campaign.
+     *
      * @param string $elementType [browsers|carriers|categories|countries|devices|languages|operating_systems|sites|keywords|ip_ranges]
      * @param string $id
      * @param string $type [targeted|blocked]
      * @param array $data
      *
-     * @return array
+     * @return boolean
      */
     public function replaceElement($elementType, $id, $type, array $data = array())
     {
@@ -179,8 +181,9 @@ class Campaign extends AbstractApi
         return $this->put($path, $data);
     }
 
-    /*
-     * Remove targeted/blocked element from a campaign
+    /**
+     * Remove targeted/blocked element from a campaign.
+     *
      * @param string $elementType [browsers|carriers|categories|countries|devices|languages|operating_systems|sites|keywords|ip_ranges]
      * @param string $id
      * @param string $type [targeted|blocked]
@@ -195,8 +198,9 @@ class Campaign extends AbstractApi
         return $this->delete($path, $data);
     }
 
-    /*
-     * Remove all targeted/blocked elements from a campaign
+    /**
+     * Remove all targeted/blocked elements from a campaign.
+     *
      * @param string $elementType [browsers|carriers|categories|countries|devices|languages|operating_systems|sites|keywords|ip_ranges]/all
      * @param string $id
      * @param string $type [targeted|blocked]

--- a/lib/Exads/Api/StatisticsAdvertiser.php
+++ b/lib/Exads/Api/StatisticsAdvertiser.php
@@ -10,6 +10,8 @@ class StatisticsAdvertiser extends AbstractStatistics
     protected $subGroup = 'advertiser';
 
     /**
+     * Get advertiser statistics by variation.
+     *
      * @param array $params
      *
      * @return array
@@ -17,5 +19,17 @@ class StatisticsAdvertiser extends AbstractStatistics
     public function variation(array $params = array())
     {
         return $this->get($this->getPath('variation'), $params);
+    }
+
+    /**
+     * Get advertiser statistics by campaign.
+     *
+     * @param array $params
+     *
+     * @return array
+     */
+    public function campaign(array $params = array())
+    {
+        return $this->get($this->getPath('campaign'), $params);
     }
 }

--- a/lib/Exads/Client.php
+++ b/lib/Exads/Client.php
@@ -8,6 +8,17 @@ use Exads\Api\SimpleXMLElement;
  * Simple PHP Exads client.
  *
  * @link http://github.com/exads/php-exads-api
+ *
+ * @property-read Api\Campaign $campaigns
+ * @property-read Api\Login $login
+ * @property-read Api\Collection $collections
+ * @property-read Api\PaymentAdvertiser $payments_advertiser
+ * @property-read Api\PaymentPublisher $payments_publisher
+ * @property-read Api\Site $sites
+ * @property-read Api\StatisticsAdvertiser $statistics_advertiser
+ * @property-read Api\StatisticsPublisher $statistics_publisher
+ * @property-read Api\User $user
+ * @property-read Api\Zone $zones
  */
 class Client implements ClientInterface
 {
@@ -161,7 +172,7 @@ class Client implements ClientInterface
      * @param array  $params
      * @param bool   $decode
      *
-     * @return array
+     * @return array|string
      */
     public function get($path, array $params = array(), $decode = true)
     {
@@ -212,7 +223,7 @@ class Client implements ClientInterface
      * @param mixed  $data
      * @param array  $headers
      *
-     * @return mixed
+     * @return bool|string
      */
     public function post($path, $data = null, $headers = [])
     {
@@ -229,7 +240,7 @@ class Client implements ClientInterface
      * @param string $path
      * @param mixed  $data
      *
-     * @return array
+     * @return bool|string
      */
     public function put($path, $data = null)
     {
@@ -244,7 +255,7 @@ class Client implements ClientInterface
      * @param string $path
      * @param mixed  $data
      *
-     * @return array
+     * @return bool|string
      */
     public function delete($path, $data = null)
     {
@@ -359,12 +370,12 @@ class Client implements ClientInterface
     /**
      * @param string $path
      * @param string $method
-     * @param string $data
+     * @param string|array $data
      * @param array $headers
      *
      * @throws \Exception If anything goes wrong on curl request
      *
-     * @return bool|SimpleXMLElement|string
+     * @return bool|string
      */
     protected function runRequest($path, $method = 'GET', $data = '', $headers = [])
     {

--- a/lib/Exads/TestClient.php
+++ b/lib/Exads/TestClient.php
@@ -7,13 +7,14 @@ class TestClient extends Client
     /**
      * @param string $path
      * @param string $method
-     * @param string $data
+     * @param string|array $data
+     * @param array $headers
      *
      * @throws \Exception always!
      *
      * @return string
      */
-    protected function runRequest($path, $method = 'GET', $data = '')
+    protected function runRequest($path, $method = 'GET', $data = '', $headers = [])
     {
         throw new \Exception('not available');
     }

--- a/lib/Exads/TestUrlClient.php
+++ b/lib/Exads/TestUrlClient.php
@@ -6,6 +6,7 @@ class TestUrlClient extends Client
 {
     /**
      * @param string $path
+     * @param array  $params
      * @param bool   $decode
      *
      * @return array
@@ -22,17 +23,32 @@ class TestUrlClient extends Client
     /**
      * @param string $path
      * @param string $method
-     * @param string $data
+     * @param string|array $data
+     * @param array $headers
      *
      * @throws \Exception If anything goes wrong on curl request
      *
-     * @return string
+     * @return array
      */
-    protected function runRequest($path, $method = 'GET', $data = '')
+    protected function runRequest($path, $method = 'GET', $data = '', $headers = [])
     {
-        return array(
+        $result = array(
             'method' => $method,
             'path' => $path,
         );
+
+        // Try decode data
+        if (is_string($data)) {
+            $decoded = json_decode($data, true);
+            if (JSON_ERROR_NONE === json_last_error()) {
+                $data = $decoded;
+            }
+        }
+        // Add data element only if it present
+        if ($data) {
+            $result['data'] = $data;
+        }
+
+        return $result;
     }
 }

--- a/test/Exads/Tests/ClientTest.php
+++ b/test/Exads/Tests/ClientTest.php
@@ -4,12 +4,12 @@ namespace Exads\Tests;
 
 use Exads\Client;
 use Exads\ClientInterface;
-use Exads\Exception\InvalidArgumentException;
+use InvalidArgumentException;
 
 class ClientTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      */
     public function should_instanciate_client_class()
@@ -19,7 +19,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      * @expectedException InvalidArgumentException
      */
@@ -30,7 +30,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      */
     public function should_return_api_url()
@@ -40,7 +40,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      */
     public function should_find_correct_port()
@@ -53,7 +53,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      */
     public function should_update_port()
@@ -64,7 +64,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      */
     public function response_should_be_0_by_default()
@@ -74,7 +74,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      */
     public function should_decode_valid_json()
@@ -91,7 +91,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      */
     public function test_empty_json_decode()
@@ -104,7 +104,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      */
     public function test_malformed_json_should_return_error()
@@ -121,7 +121,7 @@ class ClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\Client
+     * @covers \Exads\Client
      * @test
      * @dataProvider getApiClassesProvider
      */

--- a/test/Exads/Tests/TestClientTest.php
+++ b/test/Exads/Tests/TestClientTest.php
@@ -3,11 +3,12 @@
 namespace Exads\Tests;
 
 use Exads\TestClient;
+use Exception;
 
 class TestClientTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers Exads\TestClient
+     * @covers \Exads\TestClient
      * @test
      * @expectedException Exception
      */
@@ -18,7 +19,7 @@ class TestClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\TestClient
+     * @covers \Exads\TestClient
      * @test
      * @expectedException Exception
      */
@@ -29,18 +30,18 @@ class TestClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\TestClient
+     * @covers \Exads\TestClient
      * @test
      * @expectedException Exception
      */
     public function test_post_method_not_available()
     {
         $client = new TestClient('http://localhost');
-        $res = $client->post('does_not_exist', 'POST method not available');
+        $client->post('does_not_exist', 'POST method not available');
     }
 
     /**
-     * @covers Exads\TestClient
+     * @covers \Exads\TestClient
      * @test
      * @expectedException Exception
      */

--- a/test/Exads/Tests/TestUrlClientTest.php
+++ b/test/Exads/Tests/TestUrlClientTest.php
@@ -7,7 +7,7 @@ use Exads\TestUrlClient;
 class TestUrlClientTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers Exads\TestUrlClient
+     * @covers \Exads\TestUrlClient
      * @test
      */
     public function test_get_returns_path_and_method()
@@ -18,7 +18,7 @@ class TestUrlClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\TestUrlClient
+     * @covers \Exads\TestUrlClient
      * @test
      */
     public function test_delete_returns_path_and_method()
@@ -29,7 +29,7 @@ class TestUrlClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\TestUrlClient
+     * @covers \Exads\TestUrlClient
      * @test
      */
     public function test_post_returns_path_and_method()
@@ -43,7 +43,7 @@ class TestUrlClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @covers Exads\TestUrlClient
+     * @covers \Exads\TestUrlClient
      * @test
      */
     public function test_put_returns_path_and_method()

--- a/test/Exads/Tests/UrlsTest.php
+++ b/test/Exads/Tests/UrlsTest.php
@@ -327,6 +327,9 @@ class UrlsTest extends \PHPUnit_Framework_TestCase
         $res = $this->client->api('statistics_advertiser')->browser();
         $this->assertEquals($res, array('method' => 'GET', 'path' => 'statistics/advertiser/browser'));
 
+        $res = $this->client->api('statistics_advertiser')->campaign();
+        $this->assertEquals($res, array('method' => 'GET', 'path' => 'statistics/advertiser/campaign'));
+
         $res = $this->client->api('statistics_advertiser')->carrier();
         $this->assertEquals($res, array('method' => 'GET', 'path' => 'statistics/advertiser/carrier'));
 
@@ -359,6 +362,9 @@ class UrlsTest extends \PHPUnit_Framework_TestCase
 
         $res = $this->client->statistics_advertiser->browser();
         $this->assertEquals($res, array('method' => 'GET', 'path' => 'statistics/advertiser/browser'));
+
+        $res = $this->client->statistics_advertiser->campaign();
+        $this->assertEquals($res, array('method' => 'GET', 'path' => 'statistics/advertiser/campaign'));
 
         $res = $this->client->statistics_advertiser->carrier();
         $this->assertEquals($res, array('method' => 'GET', 'path' => 'statistics/advertiser/carrier'));

--- a/test/Exads/Tests/UrlsTest.php
+++ b/test/Exads/Tests/UrlsTest.php
@@ -6,6 +6,7 @@ use Exads\TestUrlClient;
 
 class UrlsTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var TestUrlClient */
     private $client;
 
     public function setup()
@@ -39,17 +40,33 @@ class UrlsTest extends \PHPUnit_Framework_TestCase
         $res = $this->client->api('campaigns')->copy(1);
         $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/copy'));
 
-        $res = $this->client->api('campaigns')->remove(1);
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/delete'));
+        $res = $this->client->api('campaigns')->remove(array(1));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'campaigns/delete',
+            'data' => array(1),
+        ));
 
-        $res = $this->client->api('campaigns')->pause(1);
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/pause'));
+        $res = $this->client->api('campaigns')->pause(array(1));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'campaigns/pause',
+            'data' => array(1),
+        ));
 
-        $res = $this->client->api('campaigns')->play(1);
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/play'));
+        $res = $this->client->api('campaigns')->play(array(1));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'campaigns/play',
+            'data' => array(1),
+        ));
 
-        $res = $this->client->api('campaigns')->restore(1);
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/restore'));
+        $res = $this->client->api('campaigns')->restore(array(1));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'campaigns/restore',
+            'data' => array(1),
+        ));
 
         $res = $this->client->campaigns->all();
         $this->assertEquals($res, array('method' => 'GET', 'path' => 'campaigns'));
@@ -60,17 +77,33 @@ class UrlsTest extends \PHPUnit_Framework_TestCase
         $res = $this->client->campaigns->copy(1);
         $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/copy'));
 
-        $res = $this->client->campaigns->remove(1);
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/delete'));
+        $res = $this->client->campaigns->remove(array(1, 2));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'campaigns/delete',
+            'data' => array(1, 2),
+        ));
 
-        $res = $this->client->campaigns->pause(1);
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/pause'));
+        $res = $this->client->campaigns->pause(array(1, 2));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'campaigns/pause',
+            'data' => array(1, 2),
+        ));
 
-        $res = $this->client->campaigns->play(1);
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/play'));
+        $res = $this->client->campaigns->play(array(1, 2));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'campaigns/play',
+            'data' => array(1, 2),
+        ));
 
-        $res = $this->client->campaigns->restore(1);
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'campaigns/1/restore'));
+        $res = $this->client->campaigns->restore(array(1, 2));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'campaigns/restore',
+            'data' => array(1, 2),
+        ));
     }
 
     /**
@@ -174,16 +207,32 @@ class UrlsTest extends \PHPUnit_Framework_TestCase
     public function test_login_methods()
     {
         $res = $this->client->api('login')->getToken('aaa', 'bbb');
-        $this->assertEquals($res, array('method' => 'POST', 'path' => 'login'));
+        $this->assertEquals($res, array(
+            'method' => 'POST',
+            'path' => 'login',
+            'data' => array('username' => 'aaa', 'password' => 'bbb'),
+        ));
 
         $res = $this->client->login->getToken('aaa', 'bbb');
-        $this->assertEquals($res, array('method' => 'POST', 'path' => 'login'));
+        $this->assertEquals($res, array(
+            'method' => 'POST',
+            'path' => 'login',
+            'data' => array('username' => 'aaa', 'password' => 'bbb'),
+        ));
 
         $res = $this->client->api('login')->getToken('aaa');
-        $this->assertEquals($res, array('method' => 'POST', 'path' => 'login'));
+        $this->assertEquals($res, array(
+            'method' => 'POST',
+            'path' => 'login',
+            'data' => array('api_token' => 'aaa'),
+        ));
 
         $res = $this->client->login->getToken('aaa');
-        $this->assertEquals($res, array('method' => 'POST', 'path' => 'login'));
+        $this->assertEquals($res, array(
+            'method' => 'POST',
+            'path' => 'login',
+            'data' => array('api_token' => 'aaa'),
+        ));
     }
 
     /**
@@ -425,26 +474,50 @@ class UrlsTest extends \PHPUnit_Framework_TestCase
         $res = $this->client->api('user')->show();
         $this->assertEquals($res, array('method' => 'GET', 'path' => 'user'));
 
-        $res = $this->client->api('user')->update(array('asdf' => 'asdf'));
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'user'));
+        $res = $this->client->api('user')->update(array('firstname' => 'asdf'));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'user',
+            'data' => array('firstname' => 'asdf'),
+        ));
 
-        $res = $this->client->api('user')->changepassword('asdf', 'asdf');
-        $this->assertEquals($res, array('method' => 'POST', 'path' => 'user/changepassword'));
+        $res = $this->client->api('user')->changepassword('asdf', 'asdf_new');
+        $this->assertEquals($res, array(
+            'method' => 'POST',
+            'path' => 'user/changepassword',
+            'data' => array('password' => 'asdf', 'new_password' => 'asdf_new'),
+        ));
 
         $res = $this->client->api('user')->resetpassword('asdf@asdf.com', 'asdf');
-        $this->assertEquals($res, array('method' => 'POST', 'path' => 'user/resetpassword'));
+        $this->assertEquals($res, array(
+            'method' => 'POST',
+            'path' => 'user/resetpassword',
+            'data' => array('email' => 'asdf@asdf.com', 'username' => 'asdf', 'token' => null),
+        ));
 
         $res = $this->client->user->show();
         $this->assertEquals($res, array('method' => 'GET', 'path' => 'user'));
 
-        $res = $this->client->user->update(array('asdf' => 'asdf'));
-        $this->assertEquals($res, array('method' => 'PUT', 'path' => 'user'));
+        $res = $this->client->user->update(array('firstname' => 'asdf'));
+        $this->assertEquals($res, array(
+            'method' => 'PUT',
+            'path' => 'user',
+            'data' => array('firstname' => 'asdf'),
+        ));
 
-        $res = $this->client->user->changepassword('asdf', 'asdf');
-        $this->assertEquals($res, array('method' => 'POST', 'path' => 'user/changepassword'));
+        $res = $this->client->user->changepassword('asdf', 'asdf_new');
+        $this->assertEquals($res, array(
+            'method' => 'POST',
+            'path' => 'user/changepassword',
+            'data' => array('password' => 'asdf', 'new_password' => 'asdf_new'),
+        ));
 
         $res = $this->client->user->resetpassword('asdf@asdf.com', 'asdf');
-        $this->assertEquals($res, array('method' => 'POST', 'path' => 'user/resetpassword'));
+        $this->assertEquals($res, array(
+            'method' => 'POST',
+            'path' => 'user/resetpassword',
+            'data' => array('email' => 'asdf@asdf.com', 'username' => 'asdf', 'token' => null),
+        ));
     }
 
     /**


### PR DESCRIPTION
Hello!

I added a new method for **get advertiser statistics by campaign** API action that is present in API v2:
`get /statistics/advertiser/campaign`

Additionally, I fixed a lot of **errors in unit tests**, fixed argument and return types for few methods in docblocks.

**Please merge it.**
Thanks.